### PR TITLE
logback-spring.xml 생성 및 controller에서의 Request와 Response의 파라미터를 Log로 남김

### DIFF
--- a/blackyakb2c/src/main/java/com/blackyak/b2c/api/order/controller/OrderController.java
+++ b/blackyakb2c/src/main/java/com/blackyak/b2c/api/order/controller/OrderController.java
@@ -9,12 +9,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.blackyak.b2c.api.order.service.OrderService;
 import com.blackyak.b2c.api.order.vo.OrderStateVo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/orders")
@@ -30,8 +34,21 @@ public class OrderController {
 												     @PathVariable("coOrderNo") String coOrderNo, 
 												     OrderStateVo.Request request){	
 		
+		log.info(request.getCoOrderNo() + " / " + request.getCoSequence());
+		
 		List<OrderStateVo.Response> Response = orderService.findOrderState(request);
 		
+		ObjectMapper objectMapper = new ObjectMapper();
+		
+		try {
+			for (OrderStateVo.Response orderResponse : Response) {
+	            String JsonResponse = objectMapper.writeValueAsString(orderResponse);
+	            log.info("ResponseResult: " + JsonResponse);
+	        }
+		} catch (JsonProcessingException e) {
+			log.error("JsonFail :", e);
+		}
+						
 		return Response;
 	}	
 }

--- a/blackyakb2c/src/main/java/com/blackyak/b2c/api/product/controller/ProductController.java
+++ b/blackyakb2c/src/main/java/com/blackyak/b2c/api/product/controller/ProductController.java
@@ -7,12 +7,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.blackyak.b2c.api.product.service.ProductService;
 import com.blackyak.b2c.api.product.vo.ProductVo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/products")
@@ -26,11 +30,22 @@ public class ProductController {
 	@GetMapping("/product/{productCode}")
 	public ProductVo.Response getProduct(@Parameter(description = "제품코드") 
 										 @PathVariable("productCode") String productCode, 
-										 ProductVo.Request request){		
+										 ProductVo.Request request){	
+		
+		log.info(request.getCompanyCode() + " / " + request.getProductCode()+ " / " + request.getColorCode() + " / " + request.getSizeCode());
 					
 		request.setProductCode(productCode);
 		ProductVo.Response response = productService.selectProductInfo(request);
-				
+		
+		ObjectMapper objectMapper = new ObjectMapper();
+		
+		try {
+            String JsonResponse = objectMapper.writeValueAsString(response);
+            log.info("ResponseResult: " + JsonResponse);
+		} catch (JsonProcessingException e) {
+			log.error("JsonFail :", e);
+		}	
+		
 		return response;		
 	}
 	

--- a/blackyakb2c/src/main/resources/application.yml
+++ b/blackyakb2c/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     properties:
       hibernate:
         '[format_sql]': true
-    
+
       
 
     

--- a/blackyakb2c/src/main/resources/logback-spring.xml
+++ b/blackyakb2c/src/main/resources/logback-spring.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<!-- 파일의 변경을 확인 하여 변경시 갱신 -->
+<configuration scan="true">
+	
+	<!-- 로그 파일이 저장될 경로 -->
+    <property name="LOG_PATH" value="/Users/ADMIN/logback"/>
+    
+    <!-- 로그 파일 이름 -->
+    <property name="LOG_FILE_NAME" value="api_log"/>
+    
+    <!-- 에러 로그 파일 이름 -->
+    <property name="ERR_LOG_FILE_NAME" value="error_log"/>
+    
+    <!-- 로그 출력 패턴 -->
+    <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] : [%logger{0}:%line] - %msg%n"/>
+	
+	<!-- 로그 레벨 -->
+	<property name="LOG_LEVEL" value="info"/>
+	
+	<!-- CONSOLE에 로그 출력 세팅 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    
+    <!-- File에 로그 출력 세팅 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 경로 설정 -->
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+
+        <!-- 출력패턴 설정-->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+			
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">				
+                <!-- 파일당 최고 용량 -->
+                <maxFileSize>10KB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            
+            <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거-->
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+    </appender>
+    
+    <!-- Error File에 로그 출력 세팅 -->
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<filter class="ch.qos.logback.classic.filter.LevelFilter">
+			<level>ERROR</level>
+			<onMatch>ACCEPT</onMatch>
+			<onMismatch>DENY</onMismatch>
+		</filter>
+        <!-- 파일 경로 설정 -->
+        <file>${LOG_PATH}/${ERR_LOG_FILE_NAME}.log</file>
+
+        <!-- 출력패턴 설정-->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			
+            <fileNamePattern>${LOG_PATH}/${ERR_LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+			
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">				
+                <!-- 파일당 최고 용량 -->
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            
+            <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거-->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+    
+    <!-- root 레벨 설정 -->
+    <root level="${LOG_LEVEL}">		
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ERROR"/>         
+    </root>
+	
+</configuration>


### PR DESCRIPTION
**1. AS-IS**
 - Logging 적용이 되어있지 않음. 

**2. TO-BE**
 - logback-spring.xml 생성.
 - OrderController.java와 ProductController.java에서
   Request의 파라미터를 Log.info로 console과 파일 생성하여 Log를 남기고
   Response의 Java객체를 ObjectMapper를 사용하여 Json으로 변경하여
   console과 파일로 Log생성   

**3. TEST - Swagger를 통해 진행**
**3.1 Order**
3.1.1 주문상태를 가져오는 List - console에 찍힌 Log
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/d0c42c9c-c9d4-4633-9d2d-c96de79dd27c)

3.1.2 주문상태를 가져오는 List - local에 생성된 파일의 Log
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/d5685302-11cd-48e2-bcd2-61d7b2d6b8cf)

**3.2 Product**
3.2.1 주문상태를 가져오는 List - console에 찍힌 Log
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/4187960e-17a1-4e72-9b0e-700035c0bed9)

3.2.2 주문상태를 가져오는 List - local에 생성된 파일의 Log
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/1be558d1-da01-4cc3-bda5-2b88ce427fc8)
