### PR TITLE
개발/운영 환경분리

### DIFF
--- a/blackyakb2c/src/main/resources/application-local.yml
+++ b/blackyakb2c/src/main/resources/application-local.yml
@@ -2,6 +2,9 @@ server:
   port: '8080'
   
 spring:
+  config:
+    activate:
+      on-profile: local
   application:
     name: blackyakb2c-local
   datasource:

--- a/blackyakb2c/src/main/resources/application-local.yml
+++ b/blackyakb2c/src/main/resources/application-local.yml
@@ -8,20 +8,7 @@ spring:
   application:
     name: blackyakb2c-local
   datasource:
-  #DB설정
-    driver-class-name: oracle.jdbc.driver.OracleDriver
     url: jdbc:oracle:thin:@121.254.249.77:1521:YAKERP
-    username: US_B2C    
-    password: US_B2C
-  jpa:    
-    open-in-view: false
-    database: oracle
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        '[format_sql]': true
 
       
 

--- a/blackyakb2c/src/main/resources/application-local.yml
+++ b/blackyakb2c/src/main/resources/application-local.yml
@@ -1,0 +1,31 @@
+server:
+  port: '8080'
+  
+spring:
+  application:
+    name: blackyakb2c-local
+  datasource:
+  #DB설정
+    driver-class-name: oracle.jdbc.driver.OracleDriver
+    url: jdbc:oracle:thin:@121.254.249.77:1521:YAKERP
+    username: US_B2C    
+    password: US_B2C
+  jpa:    
+    open-in-view: false
+    database: oracle
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        '[format_sql]': true
+
+      
+
+    
+    
+    
+    
+
+
+    

--- a/blackyakb2c/src/main/resources/application-prod.yml
+++ b/blackyakb2c/src/main/resources/application-prod.yml
@@ -2,6 +2,9 @@ server:
   port: '8081'
   
 spring:
+  config:
+    activate:
+      on-profile: prod
   application:
     name: blackyakb2c-prod
   datasource:

--- a/blackyakb2c/src/main/resources/application-prod.yml
+++ b/blackyakb2c/src/main/resources/application-prod.yml
@@ -1,0 +1,31 @@
+server:
+  port: '8081'
+  
+spring:
+  application:
+    name: blackyakb2c-prod
+  datasource:
+  #DB설정
+    driver-class-name: oracle.jdbc.driver.OracleDriver
+    url: jdbc:oracle:thin:@121.254.249.72:9521:YAKERP
+    username: US_B2C    
+    password: US_B2C
+  jpa:    
+    open-in-view: false
+    database: oracle
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        '[format_sql]': true
+
+      
+
+    
+    
+    
+    
+
+
+    

--- a/blackyakb2c/src/main/resources/application-prod.yml
+++ b/blackyakb2c/src/main/resources/application-prod.yml
@@ -8,20 +8,7 @@ spring:
   application:
     name: blackyakb2c-prod
   datasource:
-  #DB설정
-    driver-class-name: oracle.jdbc.driver.OracleDriver
     url: jdbc:oracle:thin:@121.254.249.72:9521:YAKERP
-    username: US_B2C    
-    password: US_B2C
-  jpa:    
-    open-in-view: false
-    database: oracle
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        '[format_sql]': true
 
       
 

--- a/blackyakb2c/src/main/resources/application.yml
+++ b/blackyakb2c/src/main/resources/application.yml
@@ -1,8 +1,22 @@
-spring:
+ spring:
   profiles:
-    default: local
-
-      
+      default: local
+  application:
+    name: blackyakb2c-prod
+  datasource:
+  #DB설정
+    driver-class-name: oracle.jdbc.driver.OracleDriver
+    username: US_B2C    
+    password: US_B2C
+  jpa:    
+    open-in-view: false
+    database: oracle
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        '[format_sql]': true     
 
     
     

--- a/blackyakb2c/src/main/resources/application.yml
+++ b/blackyakb2c/src/main/resources/application.yml
@@ -1,13 +1,6 @@
-#로컬환경
 spring:
   profiles:
-    active: local
-
----
-#운영환경
-spring:
-  profiles:
-    active: prod
+    default: local
 
       
 

--- a/blackyakb2c/src/main/resources/application.yml
+++ b/blackyakb2c/src/main/resources/application.yml
@@ -1,22 +1,13 @@
-server:
-  port: '8080'
-  
+#로컬환경
 spring:
-  datasource:
-  #DB설정
-    driver-class-name: oracle.jdbc.driver.OracleDriver
-    url: jdbc:oracle:thin:@121.254.249.77:1521:YAKERP
-    username: US_B2C    
-    password: US_B2C
-  jpa:    
-    open-in-view: false
-    database: oracle
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        '[format_sql]': true
+  profiles:
+    active: local
+
+---
+#운영환경
+spring:
+  profiles:
+    active: prod
 
       
 


### PR DESCRIPTION
**1. AS-IS**
 - 개발/운영 환경분리가 되어있지 않음.
 - application.yml 하나에 정보 설정하였음.
 - 실배포 서비스라 테스트 시 application.yml의 설정된 정보를 수정해줘야함.

**2. TO-BE**
 - application.yml의 파일을 나눠서 개발/운영 환경분리
 - 현 시스템은 local, prod만 존재하기때문에
   application-local.yml / application-prod.yml 파일 생성
 - 각 환경의 포트번호와 데이터베이스 정보를 저장
 - application.yml 파일에는 현재 개발하고 있는 환경을 지정
    
**3. TEST**
 **[local 실행 시]**
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/199fef12-a5a7-4fad-a2d7-8e383ea97891)
   
 **[prod 실행 시]**
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/e505ed51-bb22-46bd-ac9f-fb4f29abacb6)
