### PR TITLE
JUnit5 적용 테스트

### DIFF
--- a/blackyakb2c/build.gradle
+++ b/blackyakb2c/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 	// LocalDateTime
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.core:jackson-databind'    
+    
+    // JUnit5
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.5.2' 
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
 	
 }
 

--- a/blackyakb2c/src/test/java/com/blackyak/b2c/OrderControllerTest.java
+++ b/blackyakb2c/src/test/java/com/blackyak/b2c/OrderControllerTest.java
@@ -1,0 +1,43 @@
+package com.blackyak.b2c;
+
+import com.blackyak.b2c.api.order.vo.OrderStateVo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testGetOrderState() throws Exception {
+        // 요청 객체 생성
+        OrderStateVo.Request request = new OrderStateVo.Request();
+        request.setCoOrderNo("20220724-BA279-B2C");
+        request.setCoSequence("1");
+
+        // API 호출 및 응답 검증
+        mockMvc.perform(MockMvcRequestBuilders.get("/orders/orderstate/{coOrderNo}", request.getCoOrderNo())
+        		.param("coSequence", request.getCoSequence())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}
+

--- a/blackyakb2c/src/test/java/com/blackyak/b2c/ProductControllerTest.java
+++ b/blackyakb2c/src/test/java/com/blackyak/b2c/ProductControllerTest.java
@@ -1,0 +1,47 @@
+package com.blackyak.b2c;
+
+import com.blackyak.b2c.api.product.vo.ProductVo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testGetProduct() throws Exception {
+        // 요청 객체 생성
+    	ProductVo.Request request = new ProductVo.Request();
+        request.setCompanyCode("003");
+        request.setProductCode("ABYSHX3915");
+        request.setColorCode("BE");
+        request.setSizeCode("235");
+
+        // API 호출 및 응답 검증
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/product/{productCode}", request.getProductCode())
+        		.param("companyCode", request.getCompanyCode())
+        		.param("colorCode", request.getColorCode())
+        		.param("sizeCode", request.getSizeCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}
+


### PR DESCRIPTION
1. AS-IS
 - JUnit 테스트 프레임워크 적용이 안되어있음.
 - swagger 및 웹브라우저를 통한 테스트만 진행

2. TO-BE
 - gradle에 JUnit5관련 의존성 추가
 - OrderControllerTest.java
   ProductControllerTest.java 생성하여 테스트코드 작성
 - MockMvc를 이용해 테스트용 MVC환경을 만들어 테스트
    
3. TEST
 [OrderControllerTest.java 테스트]
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/0ec106b7-520c-4306-821c-df7a47db6c63)
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/c6894264-b0e1-41ad-a8fa-fc26ba8d7698)
   
 [ProductControllerTest.java 테스트]
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/8abc8262-cd6e-4215-92e4-d59c8e6893d4)
![image](https://github.com/Park-Sang-soo/pssyak/assets/129250315/43ded096-5160-4fbc-9018-e7b7deceb3e7)
